### PR TITLE
Functionality for the Braze Overlay

### DIFF
--- a/Sources/Sisyphos/Extensions/XCUIApplication+CurrentPage.swift
+++ b/Sources/Sisyphos/Extensions/XCUIApplication+CurrentPage.swift
@@ -61,6 +61,12 @@ private func extract(element: XCUIElementSnapshot) -> PageElement? {
             identifier: element.identifier,
             value: element.value as? String
         )
+    case .other:
+        if element.label == "Appboy Slideup" {
+            // Made it conditional to not handle all the elements in the **other* type as they are many more.
+            return BrazeOverlay()
+        }
+        return nil
     default:
         return nil
     }

--- a/Sources/Sisyphos/Page Elements/BrazeOverlay.swift
+++ b/Sources/Sisyphos/Page Elements/BrazeOverlay.swift
@@ -1,0 +1,26 @@
+public struct BrazeOverlay: PageElement {
+    public let elementIdentifier: PageElementIdentifier
+
+    let label: String
+    let identifier: String?
+
+    public var queryIdentifier: QueryIdentifier {
+        .init(
+            elementType: .other,
+            identifier: identifier,
+            label: label,
+            value: nil,
+            descendants: []
+        )
+    }
+
+    public init(
+        file: String = #file,
+        line: UInt = #line,
+        column: UInt = #column
+    ) {
+        self.elementIdentifier = .init(file: file, line: line, column: column)
+        self.label = "Appboy Slideup"
+        self.identifier = nil
+    }
+}


### PR DESCRIPTION
### Problem Definition

The braze overlay has been captured in the **other** type and for this reason, there was no way to check its existence after extracting the elements from the XCUIElementSnapshot output.

### Solution

Created a new page element for the Braze Overlay, and set its label Appboy Slideup since XCUIElementSnapshot captures it with this label name.