### PR TITLE
Fix page names in code generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Now scrolling reliably starts from the center of the screen every time.
 - Fixes running the unit tests on macOS.
 - Fixes text extraction to correctly capture multiple variable values from a single label.
+- When staying on the same screen while it changes,
+  the code generation now produces unique page names
+  (e.g. Settings, Settings2, Settings3)
+  instead of reusing the same name each time.
 
 ## [0.1.0] - 2025-11-19
 

--- a/Sources/Sisyphos/Extensions/XCUITestCase+CodeGeneration.swift
+++ b/Sources/Sisyphos/Extensions/XCUITestCase+CodeGeneration.swift
@@ -42,8 +42,10 @@ extension XCTestCase {
             let sourceWithoutUniqueName = page.generatePageSource(pageName: identifier, applicationName: application)
             guard lastSource != sourceWithoutUniqueName else { continue }
             lastSource = sourceWithoutUniqueName
+            let pageName = identifier.generatePageName()
+            let source = page.generatePageSource(pageName: pageName, applicationName: application)
             appendToSourceFile(
-                addedContents: sourceWithoutUniqueName + "\n\n"
+                addedContents: source + "\n\n"
             )
         }
     }


### PR DESCRIPTION
There was code to generate unique names already, but it wasn't used.